### PR TITLE
Fix problem in movie searcher

### DIFF
--- a/couchpotato/core/media/movie/searcher.py
+++ b/couchpotato/core/media/movie/searcher.py
@@ -161,6 +161,9 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
         ret = False
 
         for index, q_identifier in enumerate(profile.get('qualities', [])):
+            if q_identifier == '':
+                continue # Ignore qualities that are undefined
+            
             quality_custom = {
                 'index': index,
                 'quality': q_identifier,


### PR DESCRIPTION
### Description of what this fixes:
...

### Related issues:
...

Sometimes, a movie search would cause an error that prevented a valid result from being downloaded. This is because the "final" quality is a blank string - this fix ignores such entries and causes the download to succeed.

This is the error that is seen in the logs:
ERROR [ couchpotato.core.event] Error in event "quality.single", that wasn't caught: Traceback (most recent call last):
  File "/volume1/@appstore/couchpotatoserver-custom/var/CouchPotatoServer/couchpotato/core/event.py", line 15, in runHandler
    return handler(*args, **kwargs)
  File "/volume1/@appstore/couchpotatoserver-custom/var/CouchPotatoServer/couchpotato/core/plugins/quality/main.py", line 117, in single
    quality = db.get('quality', identifier, with_doc = True)['doc']
  File "/usr/local/couchpotatoserver-custom/var/CouchPotatoServer/libs/CodernityDB/database_super_thread_safe.py", line 43, in _inner
    res = f(*args, **kwargs)
  File "/usr/local/couchpotatoserver-custom/var/CouchPotatoServer/libs/CodernityDB/database.py", line 944, in get
    raise RecordNotFound("Not found")